### PR TITLE
Add latest LTS to build matrix

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
         java: ['11', '17']
     name: UnitTests
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Add latest Ubuntu LTS to test matrix

The test workflow now includes the latest 22.04 LTS version, this should test the code on this version as part of the build process.

It should just run in parallel and not lengthen build times.


